### PR TITLE
Fix tags and their usage in Record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,26 @@
 	<groupId>com.gmail.gcolaianni5</groupId>
 	<artifactId>jris</artifactId>
 	<version>1.0.0</version>
+
+    <properties>
+        <junit.version>5.5.2</junit.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.5.2</version>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -22,6 +34,11 @@
 					<show>public</show>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+            </plugin>
 			<plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.1.0</version>
@@ -35,13 +52,13 @@
             </goals>
             <configuration>
               <outputDirectory>${basedir}/apidocs</outputDirectory>
-              <resources>          
+              <resources>
                 <resource>
                   <directory>${basedir}/target/site/apidocs</directory>
                   <filtering>false</filtering>
                 </resource>
-              </resources>              
-            </configuration>            
+              </resources>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 			</plugin>
 			<plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.gmail.gcolaianni5</groupId>
-	<artifactId>jris</artifactId>
-	<version>1.0.0</version>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.gmail.gcolaianni5</groupId>
+    <artifactId>jris</artifactId>
+    <version>1.0.0</version>
 
     <properties>
         <junit.version>5.5.2</junit.version>
@@ -24,44 +24,44 @@
         </dependency>
     </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.1</version>
-				<configuration>
-					<show>public</show>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <show>public</show>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
             </plugin>
-			<plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <!-- here the phase you need -->
-            <phase>install</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/apidocs</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${basedir}/target/site/apidocs</directory>
-                  <filtering>false</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <!-- here the phase you need -->
+                        <phase>install</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/apidocs</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/target/site/apidocs</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -72,5 +72,5 @@
                 </configuration>
             </plugin>
         </plugins>
-	</build>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 	<version>1.0.0</version>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>3.1.1</version>
 				<configuration>
 					<show>public</show>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/gmail/gcolaianni5/jris/bean/Record.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/bean/Record.java
@@ -361,7 +361,7 @@ public class Record {
 	/**
 	 * TT.
 	 */
-	private String transaltedTitle;
+	private String translatedTitle;
 	
 	/**
 	 * U1. User definable 1. This is an alphanumeric field and there is no practical limit to the length of this field.
@@ -1538,19 +1538,19 @@ public class Record {
 	}
 
 	/**
-	 * Return transaltedTitle value or reference.
-	 * @return transaltedTitle value or reference.
+	 * Return translatedTitle value or reference.
+	 * @return translatedTitle value or reference.
 	 */
-	public String getTransaltedTitle() {
-		return transaltedTitle;
+	public String getTranslatedTitle() {
+		return translatedTitle;
 	}
 
 	/**
-	 * Set transaltedTitle value or reference.
-	 * @param transaltedTitle Value to set.
+	 * Set translatedTitle value or reference.
+	 * @param translatedTitle Value to set.
 	 */
-	public void setTransaltedTitle(String transaltedTitle) {
-		this.transaltedTitle = transaltedTitle;
+	public void setTranslatedTitle(String translatedTitle) {
+		this.translatedTitle = translatedTitle;
 	}
 
 	/**
@@ -1855,8 +1855,8 @@ public class Record {
 		builder.append(translatedAuthor);
 		builder.append(", title=");
 		builder.append(title);
-		builder.append(", transaltedTitle=");
-		builder.append(transaltedTitle);
+		builder.append(", translatedTitle=");
+		builder.append(translatedTitle);
 		builder.append(", userDefinable1=");
 		builder.append(userDefinable1);
 		builder.append(", userDefinable2=");
@@ -1954,7 +1954,7 @@ public class Record {
 				Objects.equals(tertiaryTitle, record.tertiaryTitle) &&
 				Objects.equals(translatedAuthor, record.translatedAuthor) &&
 				Objects.equals(title, record.title) &&
-				Objects.equals(transaltedTitle, record.transaltedTitle) &&
+				Objects.equals(translatedTitle, record.translatedTitle) &&
 				Objects.equals(userDefinable1, record.userDefinable1) &&
 				Objects.equals(userDefinable2, record.userDefinable2) &&
 				Objects.equals(userDefinable3, record.userDefinable3) &&
@@ -1978,7 +1978,7 @@ public class Record {
 				relatedRecords, images, language, label, websiteLink, number, miscellaneous2, typeOfWork, notes, abstr2, numberOfVolumes,
 				originalPublication, publisher, publishingPlace, publicationYear, reviewedItem, researchNotes,
 				reprintEdition, section, isbnIssn, startPage, shortTitle, primaryTitle, secondaryTitle, tertiaryTitle,
-				translatedAuthor, title, transaltedTitle, userDefinable1, userDefinable2, userDefinable3,
+				translatedAuthor, title, translatedTitle, userDefinable1, userDefinable2, userDefinable3,
 				userDefinable4, userDefinable5, url, volumeNumber, publisherStandardNumber, primaryDate, accessDate);
 	}
 }

--- a/src/main/java/com/gmail/gcolaianni5/jris/bean/Record.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/bean/Record.java
@@ -272,7 +272,12 @@ public class Record {
 	 * N2. Abstract. This is a free text field and can contain alphanumeric characters. There is no practical length limit to this field.
 	 */
 	private String abstr2;
-	
+
+	/**
+	 * NV.
+	 */
+	private String numberOfVolumes;
+
 	/**
 	 * OP.
 	 */
@@ -1261,6 +1266,22 @@ public class Record {
 	}
 
 	/**
+	 * Return notes value or reference.
+	 * @return notes value or reference.
+	 */
+	public String getNumberOfVolumes() {
+		return numberOfVolumes;
+	}
+
+	/**
+	 * Set number of volumes.
+	 * @param numberOfVolumes Value to set.
+	 */
+	public void setNumberOfVolumes(String numberOfVolumes) {
+		this.numberOfVolumes = numberOfVolumes;
+	}
+
+	/**
 	 * Return originalPublication value or reference.
 	 * @return originalPublication value or reference.
 	 */
@@ -1800,6 +1821,8 @@ public class Record {
 		builder.append(notes);
 		builder.append(", abstr2=");
 		builder.append(abstr2);
+		builder.append(", numberOfVolumes=");
+		builder.append(numberOfVolumes);
 		builder.append(", originalPublication=");
 		builder.append(originalPublication);
 		builder.append(", publisher=");
@@ -1914,6 +1937,7 @@ public class Record {
 				Objects.equals(typeOfWork, record.typeOfWork) &&
 				Objects.equals(notes, record.notes) &&
 				Objects.equals(abstr2, record.abstr2) &&
+				Objects.equals(numberOfVolumes, record.numberOfVolumes) &&
 				Objects.equals(originalPublication, record.originalPublication) &&
 				Objects.equals(publisher, record.publisher) &&
 				Objects.equals(publishingPlace, record.publishingPlace) &&
@@ -1951,7 +1975,7 @@ public class Record {
 				date, databaseName, doi, databaseProvider, editor, endPage, edition, referenceId, issueNumber,
 				periodicalNameUserAbbrevation, alternativeTitle, periodicalNameStandardAbbrevation,
 				periodicalNameFullFormatJF, periodicalNameFullFormatJO, keywords, pdfLinks, fullTextLinks,
-				relatedRecords, images, language, label, websiteLink, number, miscellaneous2, typeOfWork, notes, abstr2,
+				relatedRecords, images, language, label, websiteLink, number, miscellaneous2, typeOfWork, notes, abstr2, numberOfVolumes,
 				originalPublication, publisher, publishingPlace, publicationYear, reviewedItem, researchNotes,
 				reprintEdition, section, isbnIssn, startPage, shortTitle, primaryTitle, secondaryTitle, tertiaryTitle,
 				translatedAuthor, title, transaltedTitle, userDefinable1, userDefinable2, userDefinable3,

--- a/src/main/java/com/gmail/gcolaianni5/jris/bean/Record.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/bean/Record.java
@@ -169,7 +169,7 @@ public class Record {
 	private Integer endPage;
 	
 	/**
-	 * ED.
+	 * ET.
 	 */
 	private String edition;
 	

--- a/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
@@ -130,6 +130,7 @@ public class JRis {
 		TAG_METHOD_DICTIONARY.put("M3", new MethodTypeMapping("setTypeOfWork", String.class));
 		TAG_METHOD_DICTIONARY.put("N1", new MethodTypeMapping("setNotes", String.class));
 		TAG_METHOD_DICTIONARY.put("N2", new MethodTypeMapping("setAbstr2", String.class));
+		TAG_METHOD_DICTIONARY.put("NV", new MethodTypeMapping("setNumberOfVolumes", String.class));
 		TAG_METHOD_DICTIONARY.put("OP", new MethodTypeMapping("setOriginalPublication", String.class));
 		TAG_METHOD_DICTIONARY.put("PB", new MethodTypeMapping("setPublisher", String.class));
 		TAG_METHOD_DICTIONARY.put("PP", new MethodTypeMapping("setPublishingPlace", String.class));

--- a/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
@@ -85,7 +85,7 @@ public class JRis {
 		TAG_METHOD_DICTIONARY.put("A3", new MethodTypeMapping("addTertiaryAuthor", List.class));
 		TAG_METHOD_DICTIONARY.put("A4", new MethodTypeMapping("addSubsidiaryAuthor", List.class));
 		TAG_METHOD_DICTIONARY.put("AB", new MethodTypeMapping("setAbstr", String.class));
-		TAG_METHOD_DICTIONARY.put("AA", new MethodTypeMapping("setAuthorAddress", String.class));
+		TAG_METHOD_DICTIONARY.put("AD", new MethodTypeMapping("setAuthorAddress", String.class));
 		TAG_METHOD_DICTIONARY.put("AN", new MethodTypeMapping("setAccessionNumber", String.class));
 		TAG_METHOD_DICTIONARY.put("AU", new MethodTypeMapping("addAuthor", List.class));
 		TAG_METHOD_DICTIONARY.put("AV", new MethodTypeMapping("setArchivesLocation", String.class));

--- a/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
@@ -134,7 +134,7 @@ public class JRis {
 		TAG_METHOD_DICTIONARY.put("PB", new MethodTypeMapping("setPublisher", String.class));
 		TAG_METHOD_DICTIONARY.put("PP", new MethodTypeMapping("setPublishingPlace", String.class));
 		TAG_METHOD_DICTIONARY.put("PY", new MethodTypeMapping("setPublicationYear", String.class));
-		TAG_METHOD_DICTIONARY.put("R1", new MethodTypeMapping("setReviewedItem", String.class));
+		TAG_METHOD_DICTIONARY.put("RI", new MethodTypeMapping("setReviewedItem", String.class));
 		TAG_METHOD_DICTIONARY.put("RN", new MethodTypeMapping("setResearchNotes", String.class));
 		TAG_METHOD_DICTIONARY.put("RP", new MethodTypeMapping("setReprintEdition", String.class));
 		TAG_METHOD_DICTIONARY.put("SE", new MethodTypeMapping("setSection", String.class));

--- a/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
@@ -109,7 +109,7 @@ public class JRis {
 		TAG_METHOD_DICTIONARY.put("DP", new MethodTypeMapping("setDatabaseProvider", String.class));
 		TAG_METHOD_DICTIONARY.put("ED", new MethodTypeMapping("setEditor", String.class));
 		TAG_METHOD_DICTIONARY.put("EP", new MethodTypeMapping("setEndPage", Integer.class));
-		TAG_METHOD_DICTIONARY.put("ED", new MethodTypeMapping("setEdition", String.class));
+		TAG_METHOD_DICTIONARY.put("ET", new MethodTypeMapping("setEdition", String.class));
 		TAG_METHOD_DICTIONARY.put("ID", new MethodTypeMapping("setReferenceId", String.class));
 		TAG_METHOD_DICTIONARY.put("IS", new MethodTypeMapping("setIssueNumber", Integer.class));
 		TAG_METHOD_DICTIONARY.put("J1", new MethodTypeMapping("setPeriodicalNameUserAbbrevation", String.class));

--- a/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
+++ b/src/main/java/com/gmail/gcolaianni5/jris/engine/JRis.java
@@ -147,6 +147,7 @@ public class JRis {
 		TAG_METHOD_DICTIONARY.put("T3", new MethodTypeMapping("setTertiaryTitle", String.class));
 		TAG_METHOD_DICTIONARY.put("TA", new MethodTypeMapping("setTranslatedAuthor", String.class));
 		TAG_METHOD_DICTIONARY.put("TI", new MethodTypeMapping("setTitle", String.class));
+		TAG_METHOD_DICTIONARY.put("TT", new MethodTypeMapping("setTranslatedTitle", String.class));
 		TAG_METHOD_DICTIONARY.put("U1", new MethodTypeMapping("setUserDefinable1", String.class));
 		TAG_METHOD_DICTIONARY.put("U2", new MethodTypeMapping("setUserDefinable2", String.class));
 		TAG_METHOD_DICTIONARY.put("U3", new MethodTypeMapping("setUserDefinable3", String.class));

--- a/src/test/java/com/gmail/gcolaianni5/jris/bean/RecordTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/bean/RecordTest.java
@@ -1,23 +1,17 @@
 package com.gmail.gcolaianni5.jris.bean;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.LinkedList;
 
-public class RecordTest {
+import org.junit.jupiter.api.Test;
 
-  @Rule public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule public final Timeout globalTimeout = new Timeout(10000);
+class RecordTest {
 
   /* testedClasses: Record */
   // Test written by Diffblue Cover.
   @Test
-  public void addAuthorInputNotNullOutputVoid() {
+  void addAuthorInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -29,12 +23,12 @@ public class RecordTest {
     // Assert side effects
     final LinkedList<String> linkedList = new LinkedList<String>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getAuthors());
+    assertEquals(linkedList, objectUnderTest.getAuthors());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addFirstAuthorInputNotNullOutputVoid() {
+  void addFirstAuthorInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -44,14 +38,14 @@ public class RecordTest {
     objectUnderTest.addFirstAuthor(firstAuthor);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getFirstAuthors());
+    assertEquals(linkedList, objectUnderTest.getFirstAuthors());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addFullTextLinkInputNotNullOutputVoid() {
+  void addFullTextLinkInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -61,14 +55,14 @@ public class RecordTest {
     objectUnderTest.addFullTextLink(fullTextLink);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getFullTextLinks());
+    assertEquals(linkedList, objectUnderTest.getFullTextLinks());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addImageInputNotNullOutputVoid() {
+  void addImageInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -78,14 +72,14 @@ public class RecordTest {
     objectUnderTest.addImage(image);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getImages());
+    assertEquals(linkedList, objectUnderTest.getImages());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addKeywordInputNotNullOutputVoid() {
+  void addKeywordInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -95,14 +89,14 @@ public class RecordTest {
     objectUnderTest.addKeyword(keyword);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getKeywords());
+    assertEquals(linkedList, objectUnderTest.getKeywords());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addPdfLinkInputNotNullOutputVoid() {
+  void addPdfLinkInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -112,14 +106,14 @@ public class RecordTest {
     objectUnderTest.addPdfLink(pdfLink);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getPdfLinks());
+    assertEquals(linkedList, objectUnderTest.getPdfLinks());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addRelatedRecordInputNotNullOutputVoid() {
+  void addRelatedRecordInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -129,14 +123,14 @@ public class RecordTest {
     objectUnderTest.addRelatedRecord(relatedRecord);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getRelatedRecords());
+    assertEquals(linkedList, objectUnderTest.getRelatedRecords());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addSecondaryAuthorInputNotNullOutputVoid() {
+  void addSecondaryAuthorInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -146,14 +140,14 @@ public class RecordTest {
     objectUnderTest.addSecondaryAuthor(secondaryAuthor);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getSecondaryAuthors());
+    assertEquals(linkedList, objectUnderTest.getSecondaryAuthors());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addSubsidiaryAuthorInputNotNullOutputVoid() {
+  void addSubsidiaryAuthorInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -163,14 +157,14 @@ public class RecordTest {
     objectUnderTest.addSubsidiaryAuthor(subsidiaryAuthor);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getSubsidiaryAuthors());
+    assertEquals(linkedList, objectUnderTest.getSubsidiaryAuthors());
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void addTertiaryAuthorInputNotNullOutputVoid() {
+  void addTertiaryAuthorInputNotNullOutputVoid() {
 
     // Arrange
     final Record objectUnderTest = new Record();
@@ -180,8 +174,8 @@ public class RecordTest {
     objectUnderTest.addTertiaryAuthor(tertiaryAuthor);
 
     // Assert side effects
-    final LinkedList<String> linkedList = new LinkedList<String>();
+    final LinkedList<String> linkedList = new LinkedList<>();
     linkedList.add("3");
-    Assert.assertEquals(linkedList, objectUnderTest.getTertiaryAuthors());
+    assertEquals(linkedList, objectUnderTest.getTertiaryAuthors());
   }
 }

--- a/src/test/java/com/gmail/gcolaianni5/jris/bean/TypeTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/bean/TypeTest.java
@@ -1,27 +1,23 @@
 package com.gmail.gcolaianni5.jris.bean;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TypeTest {
+import org.junit.jupiter.api.Test;
 
-  @Rule public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule public final Timeout globalTimeout = new Timeout(10000);
+class TypeTest {
 
   /* testedClasses: Type */
   // Test written by Diffblue Cover.
   @Test
-  public void valueOfInputNotNullOutputIllegalArgumentException() {
+  void valueOfInputNotNullOutputIllegalArgumentException() {
 
     // Arrange
     final String name = "a,b,c";
 
     // Act
-    thrown.expect(IllegalArgumentException.class);
-    Type.valueOf(name);
+    assertThrows(IllegalArgumentException.class, () -> {
+        Type.valueOf(name);
+    });
 
     // Method is not expected to return due to exception thrown
   }

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -60,7 +60,7 @@ class JRisTest {
     String[] expectedTags = {
         "TY", "A1", "A2", "A3", "A4", "AB", "AD", "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5",
         "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", "ET", "ID", "IS", "J1",
-        "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", /*"NV",*/ // TODO re-include NV
+        "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", "NV",
         "OP", "PB", "PP", "PY", "RI", "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include TT
         "U2", "U3", "U4", "U5", "UR", "VL", "VO", "Y1", "Y2"
     };

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -61,9 +61,8 @@ class JRisTest {
         "TY", "A1", "A2", "A3", "A4", "AB", "AD", "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5",
         "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", /*"ET",*/ "ID", "IS", "J1", // TODO re-include ET
         "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", /*"NV",*/ // TODO re-include NV
-        "OP", "PB", "PP", "PY", /*"RI",*/ "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include RI, TT
+        "OP", "PB", "PP", "PY", "RI", "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include TT
         "U2", "U3", "U4", "U5", "UR", "VL", "VO", "Y1", "Y2"
-        , "R1" // <--- TODO remove
     };
 
     JRis jris = new JRis();

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -59,7 +59,7 @@ class JRisTest {
     // tags copied from https://en.wikipedia.org/wiki/RIS_(file_format)
     String[] expectedTags = {
         "TY", "A1", "A2", "A3", "A4", "AB", "AD", "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5",
-        "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", /*"ET",*/ "ID", "IS", "J1", // TODO re-include ET
+        "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", "ET", "ID", "IS", "J1",
         "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", /*"NV",*/ // TODO re-include NV
         "OP", "PB", "PP", "PY", "RI", "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include TT
         "U2", "U3", "U4", "U5", "UR", "VL", "VO", "Y1", "Y2"

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -1,16 +1,17 @@
 package com.gmail.gcolaianni5.jris.engine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import com.gmail.gcolaianni5.jris.bean.Record;
-import com.gmail.gcolaianni5.jris.exception.JRisException;
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.Field;
+import java.util.*;
+
+import com.gmail.gcolaianni5.jris.bean.Record;
+import com.gmail.gcolaianni5.jris.exception.JRisException;
+import org.junit.jupiter.api.Test;
 
 class JRisTest {
 
@@ -46,5 +47,32 @@ class JRisTest {
     });
 
     // Method is not expected to return due to exception thrown
+  }
+
+  /**
+   * The list of expected tags was copied from https://en.wikipedia.org/wiki/RIS_(file_format)
+   * and modified to pass the current implementation (-> prepare the failing test).
+   * The following elements are not implemented: AD, ET, NV, RI, TT. but in addition we have "AA" and "R1" (typo!).
+   */
+  @Test
+  void assertTypes() throws NoSuchFieldException, IllegalAccessException {
+    // tags copied from https://en.wikipedia.org/wiki/RIS_(file_format)
+    String[] expectedTags = {
+        "TY", "A1", "A2", "A3", "A4", "AB", /*"AD",*/ "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5", // TODO re-include AD
+        "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", /*"ET",*/ "ID", "IS", "J1", // TODO re-include ET
+        "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", /*"NV",*/ // TODO re-include NV
+        "OP", "PB", "PP", "PY", /*"RI",*/ "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include RI, TT
+        "U2", "U3", "U4", "U5", "UR", "VL", "VO", "Y1", "Y2"
+        , "AA", "R1" // <--- TODO remove
+    };
+
+    JRis jris = new JRis();
+    Field f = jris.getClass().getDeclaredField("TAG_METHOD_DICTIONARY");
+    f.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    LinkedHashMap<String, MethodTypeMapping> dictionary = (LinkedHashMap) f.get(jris);
+
+    assertThat(dictionary.keySet()).containsExactlyInAnyOrder(expectedTags);
   }
 }

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -49,13 +49,9 @@ class JRisTest {
     // Method is not expected to return due to exception thrown
   }
 
-  /**
-   * The list of expected tags was copied from https://en.wikipedia.org/wiki/RIS_(file_format) (version 2019-09-03 15:36)
-   * and modified to pass the current implementation (-> prepare the failing test).
-   * The following elements are not implemented: AD, ET, NV, RI, TT. but in addition we have "AA" and "R1" (typo!).
-   */
   @Test
-  void assertTypes() throws NoSuchFieldException, IllegalAccessException {
+  void assertTags() throws NoSuchFieldException, IllegalAccessException {
+    // The list of expected tags was copied from https://en.wikipedia.org/wiki/RIS_(file_format) (version 2019-09-03 15:36)
     String[] expectedTags = {
         "TY", "A1", "A2", "A3", "A4", "AB", "AD", "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5",
         "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", "ET", "ID", "IS", "J1",

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -1,11 +1,10 @@
 package com.gmail.gcolaianni5.jris.engine;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.gmail.gcolaianni5.jris.bean.Record;
 import com.gmail.gcolaianni5.jris.exception.JRisException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -13,16 +12,12 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class JRisTest {
-
-  @Rule public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule public final Timeout globalTimeout = new Timeout(10000);
+class JRisTest {
 
   /* testedClasses: JRis */
   // Test written by Diffblue Cover.
   @Test
-  public void buildInput1NullOutputJRisException() throws IOException, JRisException {
+  void buildInput1NullOutputJRisException() throws IOException, JRisException {
 
     // Arrange
     final ArrayList<Record> records = new ArrayList<Record>();
@@ -30,23 +25,25 @@ public class JRisTest {
     final Writer writer = null;
 
     // Act
-    thrown.expect(JRisException.class);
-    JRis.build(records, writer);
+    assertThrows(JRisException.class, () -> {
+      JRis.build(records, writer);
+    });
 
     // Method is not expected to return due to exception thrown
   }
 
   // Test written by Diffblue Cover.
   @Test
-  public void buildInputNullNullOutputNullPointerException() throws JRisException, IOException {
+  void buildInputNullNullOutputNullPointerException() throws JRisException, IOException {
 
     // Arrange
     final List<Record> records = null;
     final OutputStream out = null;
 
     // Act
-    thrown.expect(NullPointerException.class);
-    JRis.build(records, out);
+    assertThrows(NullPointerException.class, () -> {
+      JRis.build(records, out);
+    });
 
     // Method is not expected to return due to exception thrown
   }

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -58,12 +58,12 @@ class JRisTest {
   void assertTypes() throws NoSuchFieldException, IllegalAccessException {
     // tags copied from https://en.wikipedia.org/wiki/RIS_(file_format)
     String[] expectedTags = {
-        "TY", "A1", "A2", "A3", "A4", "AB", /*"AD",*/ "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5", // TODO re-include AD
+        "TY", "A1", "A2", "A3", "A4", "AB", "AD", "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5",
         "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", /*"ET",*/ "ID", "IS", "J1", // TODO re-include ET
         "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", /*"NV",*/ // TODO re-include NV
         "OP", "PB", "PP", "PY", /*"RI",*/ "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include RI, TT
         "U2", "U3", "U4", "U5", "UR", "VL", "VO", "Y1", "Y2"
-        , "AA", "R1" // <--- TODO remove
+        , "R1" // <--- TODO remove
     };
 
     JRis jris = new JRis();

--- a/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
+++ b/src/test/java/com/gmail/gcolaianni5/jris/engine/JRisTest.java
@@ -50,18 +50,17 @@ class JRisTest {
   }
 
   /**
-   * The list of expected tags was copied from https://en.wikipedia.org/wiki/RIS_(file_format)
+   * The list of expected tags was copied from https://en.wikipedia.org/wiki/RIS_(file_format) (version 2019-09-03 15:36)
    * and modified to pass the current implementation (-> prepare the failing test).
    * The following elements are not implemented: AD, ET, NV, RI, TT. but in addition we have "AA" and "R1" (typo!).
    */
   @Test
   void assertTypes() throws NoSuchFieldException, IllegalAccessException {
-    // tags copied from https://en.wikipedia.org/wiki/RIS_(file_format)
     String[] expectedTags = {
         "TY", "A1", "A2", "A3", "A4", "AB", "AD", "AN", "AU", "AV", "BT", "C1", "C2", "C3", "C4", "C5",
         "C6", "C7", "C8", "CA", "CN", "CP", "CT", "CY", "DA", "DB", "DO", "DP", "ED", "EP", "ET", "ID", "IS", "J1",
         "J2", "JA", "JF", "JO", "KW", "L1", "L2", "L3", "L4", "LA", "LB", "LK", "M1", "M2", "M3", "N1", "N2", "NV",
-        "OP", "PB", "PP", "PY", "RI", "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", /*"TT",*/ "U1", // TODO re-include TT
+        "OP", "PB", "PP", "PY", "RI", "RN", "RP", "SE", "SN", "SP", "ST", "T1", "T2", "T3", "TA", "TI", "TT", "U1",
         "U2", "U3", "U4", "U5", "UR", "VL", "VO", "Y1", "Y2"
     };
 


### PR DESCRIPTION
When comparing the implementation with the [wikipedia article](https://en.wikipedia.org/wiki/RIS_(file_format)) about the RIS file format, I noticed some discrepancies. There was one Tag missing (NV) some others had either typos in the dictionary in JRis (T1 should be TI, AA should be AD, ED should be ET, had a typo in Record (transaltedTitle) and were missing in the JRis dictionary.

Before fixing this, I updated the pom to use current versions of dependencies and plugins and configured it to run the tests when calling `mvn test` and also pulled in `assertj`.